### PR TITLE
Replace color to normals of collision points

### DIFF
--- a/collisionData.h
+++ b/collisionData.h
@@ -7,11 +7,12 @@ class collisionData {
 public:
     bool collided; // Important!! Below info are all garbage if this variable is false
     point3 location;
+    vec3 normal;
     // Constructor for when collided==false (omit collision location)
     collisionData(const bool& collided=false): collided(collided) {}
     // Constructor for when collided==true
-    collisionData(const bool& collided, const point3& location)
-        : collided(collided), location(location) {}
+    collisionData(const bool& collided, const point3& location, const vec3& normal)
+        : collided(collided), location(location), normal(normal) {}
 };
 
 #endif //COLLISIONDATA_H

--- a/main.cpp
+++ b/main.cpp
@@ -20,7 +20,7 @@ color runRaytracing(const cameraSpec& camera, const std::vector<hittableObject*>
     // Compute outgoing ray
     // See documentation
     point3 rayOrigin = camera.position;
-    point3 A = point3(NDC_x, NDC_y, 1.f);
+    point3 A = point3(NDC_x, NDC_y, -1.f);
     point3 B = A * point3(camera.sensorWidth, camera.sensorHeight, camera.focal_length);
     point3 rayScreenDirection = B; // B rotated by camera.rotation. TODO: Implement matrix multiplication
     ray r(rayOrigin, rayScreenDirection);
@@ -36,7 +36,8 @@ color runRaytracing(const cameraSpec& camera, const std::vector<hittableObject*>
     // STUB: render the first object from collisions.
     // TODO: Include t in collisionData
     if (!collisions.empty()) {
-        return {0.f, 0.f, 1.f};
+        vec3 targetNormal = collisions[0].normal;
+        return 0.5f * (targetNormal + vec3(1.f, 1.f, 1.f));
     }
     else {
         return {0.f, 0.f, 0.f};
@@ -57,7 +58,7 @@ int main() {
 
     // Initialize objects
     std::vector<hittableObject*> objectList;
-    sphere sphere1(point3(0.f, 0.f, 1.3f), matrix3x3(), 0.5f);
+    sphere sphere1(point3(0.f, 0.f, -1.3f), matrix3x3(), 0.5f);
     objectList.push_back(&sphere1);
 
     // Initialize Camera

--- a/sphere.h
+++ b/sphere.h
@@ -20,7 +20,7 @@ public:
     }
 
     vec3 getNormal(const point3& pt) {
-        return (pt - this->position);
+        return unit_vector(pt - this->position);
     }
 
     collisionData rayCollisionPoint(const ray& r) override {

--- a/sphere.h
+++ b/sphere.h
@@ -19,6 +19,10 @@ public:
         this->radius = radius;
     }
 
+    vec3 getNormal(const point3& pt) {
+        return (pt - this->position);
+    }
+
     collisionData rayCollisionPoint(const ray& r) override {
         /* Ray-sphere intersection test.
          * Let ray: A+tB, sphere: center C, radius R. (all known except t)
@@ -38,11 +42,11 @@ public:
             float larger_t = (firstTerm + secondTerm)/Bsq;
             if (smaller_t > 0.f) {
                 point3 location = r.at(smaller_t);
-                return collisionData(true, location);
+                return collisionData(true, location, this->getNormal(location));
             }
             else if (larger_t > 0.f) {
                 point3 location = r.at(larger_t);
-                return collisionData(true, location);
+                return collisionData(true, location, this->getNormal(location));
             }
             else {
                 return collisionData(false);
@@ -51,7 +55,7 @@ public:
         else if (termInsideSqrt == 0.f) {
             float t = (-1.f) * dot(r.direction(), r.origin() - this->position)/Bsq;
             point3 location = r.at(t);
-            return collisionData(true, location);
+            return collisionData(true, location, this->getNormal(location));
         }
         else { // (termInsideSqrt < 0.f)
             return collisionData(false);


### PR DESCRIPTION
Replace color to normals of collision points.
![image](https://github.com/havocado/obj-raytracer/assets/47484587/055a3a58-a4f0-43ed-9697-fde2b37bd973)
- Switched camera direction to -z
- Implemented normal retrieval function of a sphere
- Implemented normal visualization