### PR TITLE
Implement Mesh class and Cube subclass with triangle soup and collision

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,6 +27,7 @@ set( GLFW-CMAKE-STARTER-SRC
         matrix3x3.h
         Mesh.h
         Cube.h
+        Mesh.cpp
 )
      
 add_executable( GLFW-CMake-starter WIN32 ${GLFW-CMAKE-STARTER-SRC} )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,8 @@ set( GLFW-CMAKE-STARTER-SRC
         sphere.h
         collisionData.h
         matrix3x3.h
+        Mesh.h
+        Cube.h
 )
      
 add_executable( GLFW-CMake-starter WIN32 ${GLFW-CMAKE-STARTER-SRC} )

--- a/Cube.h
+++ b/Cube.h
@@ -1,0 +1,32 @@
+#ifndef CUBE_H
+#define CUBE_H
+
+#include "vec3.h"
+#include "Mesh.h"
+
+class Cube: public Mesh {
+public:
+    float cubeDim[3]; // xyz
+
+    Cube(): Cube(1.f, 1.f, 1.f) {}
+
+    Cube(const point3& pos, const matrix3x3& rotMatrix): Cube(pos, rotMatrix, 1.f, 1.f, 1.f) {}
+
+    Cube(const float& dimX, const float& dimY, const float& dimZ) {
+        cubeDim[0] = dimX;
+        cubeDim[1] = dimY;
+        cubeDim[2] = dimZ;
+    }
+
+    Cube(const point3& pos, const matrix3x3& rotMatrix,
+         const float& dimX, const float& dimY, const float& dimZ)
+        : Mesh(pos, rotMatrix) {
+        cubeDim[0] = dimX;
+        cubeDim[1] = dimY;
+        cubeDim[2] = dimZ;
+    }
+
+};
+
+
+#endif //CUBE_H

--- a/Cube.h
+++ b/Cube.h
@@ -8,24 +8,49 @@ class Cube: public Mesh {
 public:
     float cubeDim[3]; // xyz
 
-    Cube(): Cube(1.f, 1.f, 1.f) {}
+    Cube(): Mesh() { initMesh(1.f, 1.f, 1.f); }
 
-    Cube(const point3& pos, const matrix3x3& rotMatrix): Cube(pos, rotMatrix, 1.f, 1.f, 1.f) {}
+    Cube(const point3& pos, const matrix3x3& rotMatrix): Mesh(pos, rotMatrix) {
+        initMesh(1.f, 1.f, 1.f);
+    }
 
-    Cube(const float& dimX, const float& dimY, const float& dimZ) {
-        cubeDim[0] = dimX;
-        cubeDim[1] = dimY;
-        cubeDim[2] = dimZ;
+    Cube(const float& dimX, const float& dimY, const float& dimZ): Mesh() {
+        initMesh(dimX, dimY, dimZ);
     }
 
     Cube(const point3& pos, const matrix3x3& rotMatrix,
          const float& dimX, const float& dimY, const float& dimZ)
         : Mesh(pos, rotMatrix) {
-        cubeDim[0] = dimX;
-        cubeDim[1] = dimY;
-        cubeDim[2] = dimZ;
+        initMesh(dimX, dimY, dimZ);
     }
 
+private:
+    void initMesh(const float& dimX, const float& dimY, const float& dimZ) {
+        this->cubeDim[0] = dimX;
+        this->cubeDim[1] = dimY;
+        this->cubeDim[2] = dimZ;
+        this->addVertex(-(dimX/2.f), -(dimY/2.f), (dimZ/2.f));
+        this->addVertex((dimX/2.f), -(dimY/2.f), (dimZ/2.f));
+        this->addVertex(-(dimX/2.f), -(dimY/2.f), -(dimZ/2.f));
+        this->addVertex((dimX/2.f), -(dimY/2.f), -(dimZ/2.f));
+        this->addVertex(-(dimX/2.f), (dimY/2.f), (dimZ/2.f));
+        this->addVertex((dimX/2.f), (dimY/2.f), (dimZ/2.f));
+        this->addVertex(-(dimX/2.f), (dimY/2.f), -(dimZ/2.f));
+        this->addVertex((dimX/2.f), (dimY/2.f), -(dimZ/2.f));
+
+        this->addFace(0, 2, 1);
+        this->addFace(1, 2, 3);
+        this->addFace(1, 7, 5);
+        this->addFace(1, 3, 7);
+        this->addFace(6, 7, 3);
+        this->addFace(6, 3, 2);
+        this->addFace(4, 6, 2);
+        this->addFace(4, 2, 0);
+        this->addFace(4, 0, 5);
+        this->addFace(5, 0, 1);
+        this->addFace(6, 5, 7);
+        this->addFace(6, 4, 5);
+    }
 };
 
 

--- a/Mesh.cpp
+++ b/Mesh.cpp
@@ -1,0 +1,68 @@
+#include "Mesh.h"
+#include "vec3.h"
+#include "ray.h"
+#include "collisionData.h"
+
+
+void Mesh::addVertex(const point3& vertexPosition) {
+    vertices.push_back(vertexPosition);
+}
+
+void Mesh::addVertex(const float& v0, const float& v1, const float& v2) {
+    vertices.emplace_back(v0, v1, v2);
+}
+
+void Mesh::addFace(const Face& face) {
+    faces.push_back(face);
+}
+
+void Mesh::addFace(const int& vInd0, const int& vInd1, const int& vInd2) {
+    faces.emplace_back(vInd0, vInd1, vInd2, this);
+}
+
+collisionData Mesh::rayCollisionPoint(const ray& r) {
+    // Return collision with minimum t
+    bool collided = false;
+    float min_t = RAY_T_MAX;
+    collisionData closestCollision;
+    for (auto & face : this->faces) {
+        collisionData coll = face.rayCollisionPoint(r);
+        if (coll.collided && coll.t < min_t) {
+            collided = true;
+            min_t = coll.t;
+            closestCollision = coll;
+        }
+    }
+    if (collided) {
+        return closestCollision;
+    }
+    else {
+        return {false};
+    }
+}
+
+// Parameters Counterclockwise order
+Face::Face(const int& vInd0, const int& vInd1, const int& vInd2, Mesh* mesh) {
+    this->mesh = mesh;
+    vertexIndices.push_back(vInd0);
+    vertexIndices.push_back(vInd1);
+    vertexIndices.push_back(vInd2);
+    // Computing normal: cross product of two edges
+    vec3 e1 = this->mesh->vertices[vInd1] - this->mesh->vertices[vInd0];
+    vec3 e2 = this->mesh->vertices[vInd2] - this->mesh->vertices[vInd1];
+    this->normal = unit_vector(cross(e1, e2));
+    // Precomputing coefficient.
+    // This is from plane equation: dot(normal,point)+coeff == 0
+    // also known as D from plane equation Ax+By+Cz+D==0
+    this->coeff = (-1.f) * dot(this->normal, this->mesh->vertices[vInd1]);
+}
+
+collisionData Face::rayCollisionPoint(const ray& r) {
+    float t = (dot(this->normal, r.origin()) + this->coeff) / (dot(this->normal, r.direction()));
+    if (t > 0.f) {
+        return {true, r, t, this->normal};
+    }
+    else {
+        return {false};
+    }
+}

--- a/Mesh.h
+++ b/Mesh.h
@@ -2,10 +2,11 @@
 #define MESH_H
 
 #include <vector>
+#include "vec3.h"
 #include "hittableObject.h"
 #include "ray.h"
+#include "collisionData.h"
 
-class Mesh;
 class Face;
 
 class Mesh: public hittableObject {
@@ -17,21 +18,15 @@ public:
 
     Mesh(const point3& pos, const matrix3x3& rotMatrix): hittableObject(pos, rotMatrix) {}
 
-    void addVertex(const point3& vertexPosition) {
-        vertices.push_back(vertexPosition);
-    }
+    void addVertex(const point3& vertexPosition);
 
-    void addFace(const Face& face) {
-        faces.push_back(face);
-    }
+    void addVertex(const float& v0, const float& v1, const float& v2);
 
-    void addFace(const int& vInd0, const int& vInd1, const int& vInd2) {
-        faces.emplace_back(vInd0, vInd1, vInd2);
-    }
+    void addFace(const Face& face);
 
-    collisionData rayCollisionPoint(const ray& r) {
+    void addFace(const int& vInd0, const int& vInd1, const int& vInd2);
 
-    }
+    collisionData rayCollisionPoint(const ray& r);
 };
 
 class Face {
@@ -43,21 +38,9 @@ public:
     float coeff; // plane equation: dot(normal, point)+coeff == 0
 
     // Counterclockwise order
-    Face(const int& vInd0, const int& vInd1, const int& vInd2) {
-        vertexIndices.push_back(vInd0);
-        vertexIndices.push_back(vInd1);
-        vertexIndices.push_back(vInd2);
-        // Computing normal: cross product of two edges
-        vec3 e1 = this->mesh->vertices[vInd1] - this->mesh->vertices[vInd0];
-        vec3 e2 = this->mesh->vertices[vInd2] - this->mesh->vertices[vInd1];
-        this->normal = unit_vector(cross(e1, e2));
-        // Precomputing coefficient.
-        // This is from plane equation: dot(normal,point)+coeff == 0
-        // also known as D from plane equation Ax+By+Cz+D==0
-        this->coeff = (-1.f) * dot(this->normal, this->mesh->vertices[vInd1]);
-    }
+    Face(const int& vInd0, const int& vInd1, const int& vInd2, Mesh* mesh);
 
-    collisionData rayCollisionPoint(const ray& )
+    collisionData rayCollisionPoint(const ray& r);
 };
 
 #endif //MESH_H

--- a/Mesh.h
+++ b/Mesh.h
@@ -1,0 +1,63 @@
+#ifndef MESH_H
+#define MESH_H
+
+#include <vector>
+#include "hittableObject.h"
+#include "ray.h"
+
+class Mesh;
+class Face;
+
+class Mesh: public hittableObject {
+public:
+    std::vector<point3> vertices; // local coordinates wrt mesh position
+    std::vector<Face> faces;
+
+    Mesh(): hittableObject() {}
+
+    Mesh(const point3& pos, const matrix3x3& rotMatrix): hittableObject(pos, rotMatrix) {}
+
+    void addVertex(const point3& vertexPosition) {
+        vertices.push_back(vertexPosition);
+    }
+
+    void addFace(const Face& face) {
+        faces.push_back(face);
+    }
+
+    void addFace(const int& vInd0, const int& vInd1, const int& vInd2) {
+        faces.emplace_back(vInd0, vInd1, vInd2);
+    }
+
+    collisionData rayCollisionPoint(const ray& r) {
+
+    }
+};
+
+class Face {
+public:
+    Mesh* mesh;
+
+    std::vector<int> vertexIndices; // size: 3
+    vec3 normal;
+    float coeff; // plane equation: dot(normal, point)+coeff == 0
+
+    // Counterclockwise order
+    Face(const int& vInd0, const int& vInd1, const int& vInd2) {
+        vertexIndices.push_back(vInd0);
+        vertexIndices.push_back(vInd1);
+        vertexIndices.push_back(vInd2);
+        // Computing normal: cross product of two edges
+        vec3 e1 = this->mesh->vertices[vInd1] - this->mesh->vertices[vInd0];
+        vec3 e2 = this->mesh->vertices[vInd2] - this->mesh->vertices[vInd1];
+        this->normal = unit_vector(cross(e1, e2));
+        // Precomputing coefficient.
+        // This is from plane equation: dot(normal,point)+coeff == 0
+        // also known as D from plane equation Ax+By+Cz+D==0
+        this->coeff = (-1.f) * dot(this->normal, this->mesh->vertices[vInd1]);
+    }
+
+    collisionData rayCollisionPoint(const ray& )
+};
+
+#endif //MESH_H

--- a/collisionData.h
+++ b/collisionData.h
@@ -1,6 +1,7 @@
 #ifndef COLLISIONDATA_H
 #define COLLISIONDATA_H
 
+#include <iostream>
 #include "vec3.h"
 #include "ray.h"
 
@@ -15,6 +16,14 @@ public:
             : collided(collided), r(r), t(t), normal(normal) {}
     // Constructor for when collided==false (omit collision location)
     collisionData(const bool& collided=false): collided(collided) {}
+
+    point3 location() const {
+        if (!collided) {
+            std::cout << "Warning: location information called for placeholder collisionData" << std::endl;
+            return {};
+        }
+        return r.at(t);
+    }
 };
 
 #endif //COLLISIONDATA_H

--- a/collisionData.h
+++ b/collisionData.h
@@ -6,13 +6,13 @@
 class collisionData {
 public:
     bool collided; // Important!! Below info are all garbage if this variable is false
-    point3 location;
+    float t;
     vec3 normal;
     // Constructor for when collided==false (omit collision location)
     collisionData(const bool& collided=false): collided(collided) {}
     // Constructor for when collided==true
-    collisionData(const bool& collided, const point3& location, const vec3& normal)
-        : collided(collided), location(location), normal(normal) {}
+    collisionData(const bool& collided, const ray& r, const float& t, const vec3& normal)
+        : collided(collided), t(t), normal(normal) {}
 };
 
 #endif //COLLISIONDATA_H

--- a/collisionData.h
+++ b/collisionData.h
@@ -2,17 +2,19 @@
 #define COLLISIONDATA_H
 
 #include "vec3.h"
+#include "ray.h"
 
 class collisionData {
 public:
     bool collided; // Important!! Below info are all garbage if this variable is false
     float t;
     vec3 normal;
-    // Constructor for when collided==false (omit collision location)
-    collisionData(const bool& collided=false): collided(collided) {}
+    ray r;
     // Constructor for when collided==true
     collisionData(const bool& collided, const ray& r, const float& t, const vec3& normal)
-        : collided(collided), t(t), normal(normal) {}
+            : collided(collided), r(r), t(t), normal(normal) {}
+    // Constructor for when collided==false (omit collision location)
+    collisionData(const bool& collided=false): collided(collided) {}
 };
 
 #endif //COLLISIONDATA_H

--- a/main.cpp
+++ b/main.cpp
@@ -17,18 +17,19 @@ color runRaytracing(const cameraSpec& camera, const std::vector<hittableObject*>
     point3 rayScreenDirection = B; // B rotated by camera.rotation. TODO: Implement matrix multiplication
     ray r(rayOrigin, rayScreenDirection);
 
-    // Compute collision
-    std::vector<collisionData> collisions;
+    // Compute closest collision
+    collisionData closestCollision(false);
     for (auto hittable : objectList) {
         collisionData coll = hittable->rayCollisionPoint(r);
-        if (coll.collided) {
-            collisions.push_back(coll);
+        if (!coll.collided) {
+            continue;
+        }
+        if (!closestCollision.collided || coll.t < closestCollision.t) {
+            closestCollision = coll;
         }
     }
-    // STUB: render the first object from collisions.
-    // TODO: Include t in collisionData
-    if (!collisions.empty()) {
-        vec3 targetNormal = collisions[0].normal;
+    if (closestCollision.collided) {
+        vec3 targetNormal = closestCollision.normal;
         return 0.5f * (targetNormal + vec3(1.f, 1.f, 1.f));
     }
     else {
@@ -50,10 +51,12 @@ int main() {
 
     // Initialize objects
     std::vector<hittableObject*> objectList;
-    /*sphere sphere1(point3(0.f, 0.f, -1.3f), matrix3x3(), 0.5f);
-    objectList.push_back(&sphere1);*/
-    Cube cube1(point3(0.f, 0.f, -2.3f), matrix3x3(), 0.5f, 0.6f, 0.3f);
+    sphere sphere1(point3(0.f, 0.f, -1.3f), matrix3x3(), 0.5f);
+    objectList.push_back(&sphere1);
+    Cube cube1(point3(1.f, 0.f, -1.3f), matrix3x3(), 0.5f, 0.6f, 0.3f);
     objectList.push_back(&cube1);
+    Cube cube2(point3(-0.7f, 0.f, -1.1f), matrix3x3(), 0.7f, 0.6f, 0.3f);
+    objectList.push_back(&cube2);
 
     // Initialize Camera
     std::cout << "Initializing Camera ......" << std::endl;
@@ -110,8 +113,8 @@ int main() {
     std::cout << "Rendering done!" << std::endl;
 
     // Swap front/back buffers
-    glfwSwapBuffers(window);
     glfwPollEvents();
+    glfwSwapBuffers(window);
 
     // Wait until the window is closed
     while (!glfwWindowShouldClose(window)) {

--- a/main.cpp
+++ b/main.cpp
@@ -8,15 +8,6 @@
 #include "Cube.h"
 #include "hittableObject.h"
 
-// Placeholder for raytracing.
-color getColorPlaceholder(const float& NDC_x, const float& NDC_y) {
-    color c;
-    c[0] = (NDC_x+1.f)*0.5f;
-    c[1] = (NDC_y+1.f)*0.5f;
-    c[2] = 1.f;
-    return c;
-}
-
 color runRaytracing(const cameraSpec& camera, const std::vector<hittableObject*>& objectList, const float& NDC_x, const float& NDC_y) {
     // Compute outgoing ray
     // See documentation

--- a/main.cpp
+++ b/main.cpp
@@ -5,6 +5,7 @@
 #include "color.h"
 #include "cameraSpec.h"
 #include "sphere.h"
+#include "Cube.h"
 #include "hittableObject.h"
 
 // Placeholder for raytracing.
@@ -40,7 +41,7 @@ color runRaytracing(const cameraSpec& camera, const std::vector<hittableObject*>
         return 0.5f * (targetNormal + vec3(1.f, 1.f, 1.f));
     }
     else {
-        return {0.f, 0.f, 0.f};
+        return {0.5f, 0.5f, 0.5f};
     }
 }
 
@@ -58,8 +59,10 @@ int main() {
 
     // Initialize objects
     std::vector<hittableObject*> objectList;
-    sphere sphere1(point3(0.f, 0.f, -1.3f), matrix3x3(), 0.5f);
-    objectList.push_back(&sphere1);
+    /*sphere sphere1(point3(0.f, 0.f, -1.3f), matrix3x3(), 0.5f);
+    objectList.push_back(&sphere1);*/
+    Cube cube1(point3(0.f, 0.f, -1.3f), matrix3x3(), 0.5f, 0.6f, 0.3f);
+    objectList.push_back(&cube1);
 
     // Initialize Camera
     std::cout << "Initializing Camera ......" << std::endl;

--- a/main.cpp
+++ b/main.cpp
@@ -61,7 +61,7 @@ int main() {
     std::vector<hittableObject*> objectList;
     /*sphere sphere1(point3(0.f, 0.f, -1.3f), matrix3x3(), 0.5f);
     objectList.push_back(&sphere1);*/
-    Cube cube1(point3(0.f, 0.f, -1.3f), matrix3x3(), 0.5f, 0.6f, 0.3f);
+    Cube cube1(point3(0.f, 0.f, -2.3f), matrix3x3(), 0.5f, 0.6f, 0.3f);
     objectList.push_back(&cube1);
 
     // Initialize Camera

--- a/matrix3x3.h
+++ b/matrix3x3.h
@@ -14,10 +14,10 @@ public:
         }
     }
 };
-
+/*
 matrix3x3 identity3x3() {
     return matrix3x3();
-}
+}*/
 
 // TODO: Make rotation matrix functions
 

--- a/ray.h
+++ b/ray.h
@@ -7,6 +7,8 @@
 
 #include "vec3.h"
 
+const float RAY_T_MAX = 1e30;
+
 class ray {
 public:
     ray() {}

--- a/sphere.h
+++ b/sphere.h
@@ -42,11 +42,11 @@ public:
             float larger_t = (firstTerm + secondTerm)/Bsq;
             if (smaller_t > 0.f) {
                 point3 location = r.at(smaller_t);
-                return collisionData(true, location, this->getNormal(location));
+                return collisionData(true, r, smaller_t, this->getNormal(location));
             }
             else if (larger_t > 0.f) {
                 point3 location = r.at(larger_t);
-                return collisionData(true, location, this->getNormal(location));
+                return collisionData(true, r, larger_t, this->getNormal(location));
             }
             else {
                 return collisionData(false);
@@ -55,7 +55,7 @@ public:
         else if (termInsideSqrt == 0.f) {
             float t = (-1.f) * dot(r.direction(), r.origin() - this->position)/Bsq;
             point3 location = r.at(t);
-            return collisionData(true, location, this->getNormal(location));
+            return collisionData(true, r, t, this->getNormal(location));
         }
         else { // (termInsideSqrt < 0.f)
             return collisionData(false);


### PR DESCRIPTION
Implemented:
- Mesh class with triangle soup
- Cube subclass
- Triangle normal calculation
- Triangle-ray intersection check
- Removed raytracing placeholder
- Use closest collision (as opposed to stub code of first detected object)
- Fixed the order of buffer swap & initial event polling